### PR TITLE
ci: migrate all GitHub workflows to use self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   validate:
     name: Validate Code & Run Tests
-    runs-on: ubuntu-latest # Use Ubuntu runner
+    runs-on: [self-hosted, linux, x64] # Use Ubuntu runner
 
     steps:
       - name: Checkout code
@@ -43,7 +43,7 @@ jobs:
     name: Publish to npm
     needs: validate # Run only if validate job succeeds
     if: startsWith(github.ref, 'refs/tags/v') # Run only on tag push
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
 
     steps:
       - name: Checkout code
@@ -81,7 +81,7 @@ jobs:
     name: Create GitHub Release
     needs: publish # Run only if publish job succeeds
     if: startsWith(github.ref, 'refs/tags/v') # Run only on tag push
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
 
     permissions:
       contents: write # Needed to create releases


### PR DESCRIPTION
Uses self-hosted runners instead of ubuntu-latest