### PR TITLE
ci: run CI on merge_group (Doctrine ADR-2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
     tags: ['v*.*.*'] # Trigger on version tags
   pull_request:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch: # Allow manual trigger
 
 jobs:


### PR DESCRIPTION
Queue-readiness per Doctrine ADR-2 default-on rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)