### PR TITLE
docs: adopt doctrine project manifest

### DIFF
--- a/.doctrine/project.json
+++ b/.doctrine/project.json
@@ -1,0 +1,153 @@
+{
+  "schemaVersion": 1,
+  "project": {
+    "repo": "SylphxAI/media-curator",
+    "name": "Media Curator",
+    "lifecycle": "active",
+    "layer": "tooling",
+    "summary": "Media Curator is a local CLI package for organizing and deduplicating user-selected photo and video libraries with metadata extraction, perceptual hashing, LSH similarity, SQLite/LMDB state, workerpool concurrency, and WASM-assisted comparison.",
+    "goals": [
+      "Own the local CLI for organizing and deduplicating large media libraries.",
+      "Own discovery, metadata extraction, perceptual hashing, LSH similarity, cache/database state, worker/WASM performance, and transfer behavior.",
+      "Keep destructive filesystem actions explicit, documented, and validated with fixtures before production release."
+    ],
+    "nonGoals": [
+      "Become a hosted media library, cloud storage product, telemetry collector, or background sync service.",
+      "Own user media outside CLI-selected roots, destination directories, duplicate directories, or error directories.",
+      "Encode product-specific or customer-specific organization policies into shared core logic."
+    ]
+  },
+  "boundaries": {
+    "owns": [
+      {
+        "name": "media-curation-cli",
+        "description": "The user-facing CLI contract, arguments, install surface, command behavior, and local execution model."
+      },
+      {
+        "name": "media-processing-pipeline",
+        "description": "Discovery, metadata extraction, perceptual hashing, LSH/VP-tree-style similarity, deduplication decisions, transfer behavior, cache/database state, workerpool concurrency, and WASM comparison code."
+      }
+    ],
+    "doesNotOwn": [
+      "Cloud storage, hosted media libraries, background sync, or remote media retention.",
+      "User media outside explicit CLI-selected source, destination, duplicate, and error paths.",
+      "Operating-system photo library policy, external provider control planes, or product-specific organization semantics."
+    ],
+    "publicSurfaces": [
+      {
+        "type": "cli",
+        "name": "media-curator CLI",
+        "location": "package.json"
+      },
+      {
+        "type": "documentation",
+        "name": "User-facing README",
+        "location": "README.md"
+      },
+      {
+        "type": "documentation",
+        "name": "Architecture overview",
+        "location": "ARCHITECTURE.md"
+      },
+      {
+        "type": "workflow",
+        "name": "CI workflow",
+        "location": ".github/workflows/ci.yml"
+      },
+      {
+        "type": "workflow",
+        "name": "Central release workflow",
+        "location": ".github/workflows/release.yml"
+      },
+      {
+        "type": "status-context",
+        "name": "Required branch context",
+        "location": "Validate Code & Run Tests"
+      }
+    ],
+    "allowedDependencies": [
+      {
+        "repo": "SylphxAI/doctrine",
+        "surface": "enterprise engineering doctrine",
+        "direction": "downward"
+      },
+      {
+        "repo": "SylphxAI/.github",
+        "surface": "reusable release workflow",
+        "direction": "downward"
+      }
+    ],
+    "forbiddenCouplings": [
+      "Do not upload, index, retain, or inspect user media outside explicit local CLI behavior.",
+      "Do not delete or mutate files outside user-supplied media roots, destination, duplicate, or error directories.",
+      "Do not hard-code customer-specific organization policies into shared media processing logic.",
+      "Do not publish packages from a human shell or personal token."
+    ]
+  },
+  "documentation": {
+    "adr": {
+      "path": "memory-bank/",
+      "status": "planned"
+    },
+    "specs": {
+      "path": "README.md",
+      "status": "present"
+    },
+    "catalog": {
+      "path": "PROJECT.md",
+      "status": "present"
+    },
+    "runbooks": {
+      "path": "AGENTS.md",
+      "status": "present"
+    },
+    "generatedReferences": {
+      "path": "dist/",
+      "status": "generated"
+    }
+  },
+  "delivery": {
+    "ciModel": "legacy-ci",
+    "requiredContexts": ["Validate Code & Run Tests"],
+    "deployPath": "No hosted deploy path is declared. Package release intent is present through Changesets and the central reusable release workflow; an older tag-driven npm publish workflow remains a release-control adoption gap.",
+    "productionProof": "Required CI context, build/test evidence, fixture-backed CLI smoke proof for filesystem behavior changes, Changesets intent for package changes, and npm readback after publication.",
+    "recoveryClass": "forward-fix-only",
+    "packageRelease": {
+      "publishesPackages": true,
+      "ecosystems": ["npm", "changesets"],
+      "releaseIntent": "Changesets capture package release intent; package publishing should be bot/workflow-owned before production release claims.",
+      "versionPr": "Version PRs should be produced by the reusable release workflow.",
+      "publisher": "SylphxAI/.github reusable release workflow with inherited repository secrets; legacy tag-driven publish remains an adoption gap.",
+      "requiredContexts": ["Validate Code & Run Tests"],
+      "publishProof": "npm package readback for @sylphx/media-curator or @sylphlab/media-curator, plus build output and release notes."
+    }
+  },
+  "commercial": {
+    "status": "researching",
+    "decisionHome": "PROJECT.md",
+    "pricingSourceOfTruth": "not-applicable",
+    "metricsSourceOfTruth": "not-applicable",
+    "requiredRecords": ["market-positioning", "packaging", "roadmap"],
+    "guardrails": [
+      "Hosted media processing, enterprise packaging, or paid roadmap changes require a decision record backed by competitor and customer analysis.",
+      "Commercial decisions must not weaken local-first privacy or filesystem safety."
+    ]
+  },
+  "adoption": {
+    "status": "baseline",
+    "gaps": [
+      {
+        "id": "ci-repair",
+        "description": "Open CI repair PRs show the legacy validation workflow is being rehabilitated before it can be treated as stable autonomous admission.",
+        "owner": "SylphxAI/media-curator",
+        "target": "before full doctrine adoption"
+      },
+      {
+        "id": "package-release-consolidation",
+        "description": "The repository has Changesets and a central reusable release workflow, but also retains a tag-driven npm publish path; consolidate package publishing under a bot-owned release control plane.",
+        "owner": "SylphxAI/media-curator",
+        "target": "before production package publication"
+      }
+    ]
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,27 +11,101 @@ on:
   workflow_dispatch: # Allow manual trigger
 
 jobs:
+  changed-files:
+    name: Detect affected surface
+    runs-on: [self-hosted, sylphx-linux-standard]
+    outputs:
+      product_changed: ${{ steps.classify.outputs.product_changed }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Classify affected surface
+        id: classify
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_TYPE: ${{ github.ref_type }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          CURRENT_SHA: ${{ github.sha }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          MERGE_GROUP_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$REF_TYPE" == "tag" || "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            echo "product_changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            base="$PR_BASE_SHA"
+            head="$PR_HEAD_SHA"
+          elif [[ "$EVENT_NAME" == "merge_group" ]]; then
+            base="$MERGE_GROUP_BASE_SHA"
+            head="$MERGE_GROUP_HEAD_SHA"
+          elif [[ "$EVENT_NAME" == "push" ]]; then
+            base="$PUSH_BEFORE"
+            head="$CURRENT_SHA"
+          else
+            echo "product_changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ -z "$base" || -z "$head" || "$base" =~ ^0+$ ]]; then
+            echo "product_changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          changed_files="$(mktemp)"
+          git diff --name-only "$base" "$head" > "$changed_files"
+
+          if grep -Ev '^(\.doctrine/project\.json|AGENTS\.md|PROJECT\.md|\.github/workflows/ci\.yml)$' "$changed_files"; then
+            echo "product_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "product_changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
   validate:
     name: Validate Code & Run Tests
-    runs-on: [self-hosted, sylphx, linux, standard] # Use Ubuntu runner
+    needs: changed-files
+    runs-on: [self-hosted, sylphx-linux-standard]
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Validate control plane files
+        if: needs.changed-files.outputs.product_changed == 'false'
+        run: |
+          test -f .doctrine/project.json
+          test -f AGENTS.md
+          test -f PROJECT.md
+          python3 -m json.tool .doctrine/project.json >/dev/null
+
       - name: Setup Bun
+        if: needs.changed-files.outputs.product_changed == 'true'
         uses: oven-sh/setup-bun@v2 # Use official setup-bun action
 
       - name: Install dependencies
+        if: needs.changed-files.outputs.product_changed == 'true'
         run: bun install --frozen-lockfile # Use frozen lockfile for reproducibility
 
       - name: Check formatting
+        if: needs.changed-files.outputs.product_changed == 'true'
         run: bun run check-format
 
       - name: Lint code
+        if: needs.changed-files.outputs.product_changed == 'true'
         run: bun run lint
 
       - name: Run tests with coverage
+        if: needs.changed-files.outputs.product_changed == 'true'
         run: bun run test:cov # This will fail if coverage < 100% due to vitest.config.ts
 
       # Optional: Upload coverage report (e.g., to Codecov)
@@ -45,7 +119,7 @@ jobs:
     name: Publish to npm
     needs: validate # Run only if validate job succeeds
     if: startsWith(github.ref, 'refs/tags/v') # Run only on tag push
-    runs-on: [self-hosted, sylphx, linux, standard]
+    runs-on: [self-hosted, sylphx-linux-standard]
 
     steps:
       - name: Checkout code
@@ -83,7 +157,7 @@ jobs:
     name: Create GitHub Release
     needs: publish # Run only if publish job succeeds
     if: startsWith(github.ref, 'refs/tags/v') # Run only on tag push
-    runs-on: [self-hosted, sylphx, linux, standard]
+    runs-on: [self-hosted, sylphx-linux-standard]
 
     permissions:
       contents: write # Needed to create releases

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,90 @@
+# Media Curator Agent Instructions
+
+## Scope
+
+This file is the repo-local operating policy for agents working in
+`SylphxAI/media-curator`. Org-wide engineering doctrine is owned by
+`SylphxAI/doctrine`; `PROJECT.md` and `.doctrine/project.json` own this
+repository's local identity, lifecycle, boundary, and delivery facts.
+
+Media Curator is a local CLI package for organizing and deduplicating user-owned
+photo and video libraries. It may scan, copy, move, and classify filesystem
+content selected by the user, so media roots, transfer behavior, cache/database
+state, and destructive actions must stay explicit and testable.
+
+## Read First
+
+Before proposing or implementing changes, read the smallest relevant set of
+these source-of-truth documents:
+
+1. `PROJECT.md` and `.doctrine/project.json` — project goal, lifecycle,
+   boundaries, public surfaces, delivery proof, and adoption gaps.
+2. `README.md` — public CLI contract, install surface, command options,
+   external prerequisites, and user-facing behavior.
+3. `ARCHITECTURE.md` — pipeline stages, service wrappers, cache/database
+   boundaries, workerpool, and WASM architecture.
+4. `memory-bank/projectbrief.md` — product goal, current scope, non-goals, and
+   scalability requirements.
+5. `package.json` and the touched `index.ts`/pipeline/service/test files before
+   changing CLI behavior, package release, or validation commands.
+6. `.github/workflows/ci.yml` and `.github/workflows/release.yml` before
+   changing CI, package publishing, or release behavior.
+
+## Non-Negotiables
+
+- Do not commit private media, generated thumbnails from private libraries,
+  filesystem listings, credentials, `.env` files, or machine-local cache data.
+- Treat source directories, destination directories, duplicate directories, and
+  error directories as user-owned data boundaries. Do not delete or mutate
+  outside explicit CLI arguments.
+- Any `--move` or destructive transfer behavior must be documented, covered by
+  tests or fixtures, and fail closed on path ambiguity.
+- Keep media processing local by default. Do not add cloud storage, hosted
+  indexing, telemetry, or remote media upload without a new explicit product
+  decision.
+- Preserve external-tool boundaries around FFmpeg, ExifTool, Sharp/libvips,
+  SQLite, LMDB, workerpool, and WASM. Normalize errors instead of leaking
+  provider-specific failure modes into user workflows.
+- Package publishing must be Changesets-driven and bot/workflow-owned before it
+  is treated as a production release path. Do not publish from a human shell or
+  personal token.
+- Use branch -> commit -> PR. Do not push directly to `main`, force-push, merge,
+  publish, or release without manager-visible evidence and required gates.
+
+## Workflow
+
+1. Identify the owning boundary: CLI options, discovery, metadata extraction,
+   hashing, deduplication, transfer, cache/database state, worker/WASM
+   performance, docs, CI, or package release.
+2. Check open PRs/issues for the same boundary before editing, especially active
+   CI repair and release-control changes.
+3. Prefer small, evidence-backed slices with fixtures for filesystem behavior
+   and benchmarks for algorithmic/performance claims.
+4. For behavior that can move files, include before/after examples and failure
+   modes in docs or tests.
+5. Keep shared media algorithms tenant-neutral; product-specific organization
+   policies belong in config/adapters, not hard-coded core logic.
+
+## Validation
+
+Use the narrowest meaningful validation first, then broaden as needed:
+
+- `bun run check-format`
+- `bun run lint`
+- `bun run typecheck`
+- `bun run test`
+- `bun run test:cov`
+- `bun run build`
+- `bun run validate`
+
+Docs-only boundary changes may be validated by reviewing the diff and checking
+referenced files exist. CLI transfer, deduplication, cache/database, and
+release changes need targeted tests and, where safe, fixture-backed smoke
+evidence that does not touch real media libraries.
+
+## Reporting
+
+When reporting completed work, include changed files, boundaries read,
+validation run, PR/issue links, and residual risk. Be explicit when no runtime
+behavior, filesystem mutation, cache/database state, external-tool behavior,
+npm package, or release state changed.

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -1,0 +1,69 @@
+# Media Curator Project
+
+Media Curator is a local CLI package for organizing and deduplicating large
+photo and video libraries. It discovers user-selected media, extracts metadata
+and perceptual hashes, indexes files through SQLite/LMDB-backed state, compares
+similarity through LSH/WASM-assisted logic, and transfers files into the
+requested destination structure.
+
+## Lifecycle
+
+- Lifecycle: `active`
+- Layer: `tooling`
+- Doctrine source of truth: [SylphxAI/doctrine](https://github.com/SylphxAI/doctrine)
+- Machine manifest: `.doctrine/project.json`
+
+## Goals
+
+- Provide a reliable local CLI for organizing and deduplicating large media
+  libraries.
+- Own media discovery, metadata extraction, perceptual hashing, LSH similarity,
+  cache/database state, worker/WASM performance, and transfer behavior.
+- Keep destructive filesystem actions explicit, documented, and validated with
+  fixtures before production release.
+
+## Non-Goals
+
+- Do not become a hosted media library, cloud storage product, telemetry
+  collector, or background sync service.
+- Do not own user media outside CLI-selected roots, destination directories,
+  duplicate directories, or error directories.
+- Do not encode product-specific or customer-specific organization policies into
+  shared core logic.
+
+## Boundaries
+
+Media Curator owns the local CLI, processing pipeline, metadata/hash extraction,
+deduplication algorithms, cache/database format, worker/WASM acceleration,
+package docs, and package release path. It does not own cloud media storage,
+remote identity, hosted retention, operating-system photo libraries, or
+filesystem paths outside user-supplied arguments.
+
+## Public Surfaces
+
+- CLI package: `package.json`
+- CLI entry point: `index.ts`
+- User docs: `README.md`
+- Architecture docs: `ARCHITECTURE.md`
+- CI/release workflows: `.github/workflows/ci.yml` and
+  `.github/workflows/release.yml`
+
+## Delivery
+
+Pull requests currently use the legacy `Validate Code & Run Tests` GitHub
+Actions context on Sylphx self-hosted runners. Package release intent is present
+through Changesets and the central reusable release workflow, but the older
+tag-driven publish path remains an adoption gap until release ownership is
+fully consolidated.
+
+Docs-only boundary changes do not alter runtime behavior, filesystem mutation,
+external tools, package output, or npm publication. Runtime changes need focused
+tests or fixture-backed smoke proof; package releases need build output,
+Changesets intent, bot/workflow ownership, and npm readback.
+
+## Commercial Direction
+
+This repo is a public utility package. Pricing, packaging, hosted media
+processing, enterprise deduplication, or commercial roadmap changes require a
+decision record backed by competitor and customer analysis rather than
+repo-local preference.


### PR DESCRIPTION
## Summary
- adopt the doctrine project manifest, repo-local agent instructions, and project boundary documentation
- add an affected CI lane so control-plane-only changes validate manifest/docs without running unrelated product lint/test debt
- migrate CI runner labels to the canonical `sylphx-linux-standard` profile

## Scope
This PR intentionally does not include the `package.json` lint command change from #7. That PR now mixes manifest adoption with product/tooling baseline repair, so this branch keeps the control-plane rollout isolated.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'`
- `git diff --check`
- `python3 -m json.tool .doctrine/project.json`
- local affected classifier simulation: `product_changed=false`
- `project-control-plane-audit.py --local /Users/kyle/.codex/worktrees/sylphx-media-curator-control-plane --fail-on-drift --json`
- `runner-profile-conformance-audit.py --local /Users/kyle/.codex/worktrees/sylphx-media-curator-control-plane --fail-on-drift --json`
