### PR TITLE
ci: grant release job write permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,5 +6,9 @@ on:
 
 jobs:
   release:
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: write
     uses: SylphxAI/.github/.github/workflows/release.yml@main
     secrets: inherit


### PR DESCRIPTION
Org default workflow permissions are read-only; the reusable release.yml (now Changesets-based) needs contents+pull-requests write, else the Release run fails at startup. Mirrors the block vex/webgpu already use.