### PR TITLE
ci: grant release job write permissions (TICK030)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,5 +6,9 @@ on:
 
 jobs:
   release:
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: write
     uses: SylphxAI/.github/.github/workflows/release.yml@main
     secrets: inherit


### PR DESCRIPTION
## Summary
- Grant \`actions/contents/pull-requests: write\` on release job.
- Closes Release \`startup_failure\` at main tip (tick014 residual).
- Main-based re-land of PR #9 intent.

## Packet
PROD-FAIL-COHORT-TICK030 · deployToken=0 · no prod_audit_pass claim

## Test plan
- [ ] Workflow YAML valid; Release no longer startup_failure when triggered