### PR TITLE
ci: move media curator to owned runners

### DIFF
--- a/.github/scripts/check-owned-runner-profiles.py
+++ b/.github/scripts/check-owned-runner-profiles.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Reject hosted, dynamic, or noncanonical CI runner selectors."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+RUNS_ON = re.compile(r"^\s*runs-on\s*:\s*(?P<value>[^#]+?)(?:\s+#.*)?$")
+LINUX = re.compile(r"^sylphx-linux-(?:control|standard|large|xlarge|2xlarge)$")
+MACOS_SIZES = {"nano", "small", "standard", "large", "xlarge", "2xlarge"}
+
+
+def unquote(value: str) -> str:
+    return value.strip().strip("\"'")
+
+
+def is_owned(value: str) -> bool:
+    value = unquote(value)
+    if LINUX.fullmatch(value):
+        return True
+    if not (value.startswith("[") and value.endswith("]")):
+        return False
+    labels = [unquote(label).lower() for label in value[1:-1].split(",") if label.strip()]
+    return (
+        len(labels) == 2
+        and labels[0] == "self-hosted"
+        and LINUX.fullmatch(labels[1]) is not None
+    ) or (
+        len(labels) == 4
+        and labels[:3] == ["self-hosted", "sylphx", "macos"]
+        and labels[3] in MACOS_SIZES
+    )
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[2]
+    workflows = sorted((root / ".github" / "workflows").glob("*.y*ml"))
+    errors: list[str] = []
+    for workflow in workflows:
+        for line, raw in enumerate(workflow.read_text(encoding="utf-8").splitlines(), 1):
+            match = RUNS_ON.match(raw)
+            if not match:
+                continue
+            value = match.group("value").strip()
+            if "${{" in value or not is_owned(value):
+                errors.append(f"{workflow.relative_to(root)}:{line}: forbidden runner selection {value!r}")
+    if errors:
+        print("\n".join(errors), file=sys.stderr)
+        return 1
+    print(f"OK: {len(workflows)} workflow(s) use static owned runner profiles")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,13 @@ on:
 jobs:
   rust:
     name: Rust CLI (ADR-168 S0)
-    runs-on: ubuntu-latest
+    runs-on: sylphx-linux-standard
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Enforce owned CI runner profiles
+        run: python3 .github/scripts/check-owned-runner-profiles.py
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
@@ -31,7 +34,7 @@ jobs:
 
   changed-files:
     name: Detect affected surface
-    runs-on: ubuntu-latest
+    runs-on: sylphx-linux-standard
     outputs:
       product_changed: ${{ steps.classify.outputs.product_changed }}
 
@@ -92,7 +95,7 @@ jobs:
   validate:
     name: Validate Code & Run Tests
     needs: [changed-files, rust]
-    runs-on: ubuntu-latest
+    runs-on: sylphx-linux-standard
 
     steps:
       - name: Checkout code
@@ -149,7 +152,7 @@ jobs:
     name: Publish to npm
     needs: validate # Run only if validate job succeeds
     if: startsWith(github.ref, 'refs/tags/v') # Run only on tag push
-    runs-on: ubuntu-latest
+    runs-on: sylphx-linux-standard
 
     steps:
       - name: Checkout code
@@ -187,7 +190,7 @@ jobs:
     name: Create GitHub Release
     needs: publish # Run only if publish job succeeds
     if: startsWith(github.ref, 'refs/tags/v') # Run only on tag push
-    runs-on: ubuntu-latest
+    runs-on: sylphx-linux-standard
 
     permissions:
       contents: write # Needed to create releases


### PR DESCRIPTION
## Summary
- replace all GitHub-hosted workflow runners with `sylphx-linux-standard`
- add an in-repo conformance gate for hosted and dynamic runner regressions

## Verification
- `python3 .github/scripts/check-owned-runner-profiles.py`
- YAML parser/static profile assertions
- `git diff --check`

Work: wi_01KYFN6993PMG8WD00Q51AE231
Claim/run: fleet-agent-work / codex-ts-false-authority-20260726