### PR TITLE
ci: drop default merge_group (Fast Trunk MQ off)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,12 @@
 name: CI
 
 on:
+  # No merge_group — Merge Queue off by default (Fast Trunk).
   push:
     branches: [main]
     tags: ['v*.*.*'] # Trigger on version tags
   pull_request:
     branches: [main]
-  merge_group:
-    types: [checks_requested]
   workflow_dispatch: # Allow manual trigger
 
 jobs:


### PR DESCRIPTION
## Summary

Fleet Fast Trunk alignment: remove default `merge_group` from ordinary CI (Merge Queue off unless intentionally enabled).

Does not change publish/release packaging authority paths.

## Test plan
- [ ] CI triggers on PR/push only
- [ ] No merge_group under `on:` for tip CI
